### PR TITLE
fixes local variable 'fingerprint' referenced before assignment

### DIFF
--- a/plugins/lookup/get_password.py
+++ b/plugins/lookup/get_password.py
@@ -94,6 +94,7 @@ class LookupModule(LookupBase):
         passphrase = None
         passbolt_uri = None
         username = None
+        fingerprint = None
         verify = True
         return_format = "password"
 


### PR DESCRIPTION
If fingerprint param is not used Ansible will throw an error: 

`An unhandled exception occurred while running the lookup plugin 'daniel_lynch.passbolt.get_password'. Error was a <class 'UnboundLocalError'>, original message: local variable 'fingerprint' referenced before assignment. local variable 'fingerprint' referenced before assignment`

This PR fixes that issue.