### PR TITLE
fixes type mismatch issue for verify parameter 

### DIFF
--- a/plugins/modules/create_group.py
+++ b/plugins/modules/create_group.py
@@ -122,6 +122,9 @@ def main():
     verify = module.params['verify']
     fingerprint = module.params['fingerprint']
 
+    if type(verify) is str and verify.lower() in ("true", "false"):
+        verify = verify.lower() == "true"
+
     Passbolt = passbolt(apiurl=passbolt_uri, privatekey=gpgkey, passphrase=passphrase, fingerprint=fingerprint,
                         verify=verify)
 

--- a/plugins/modules/create_password.py
+++ b/plugins/modules/create_password.py
@@ -142,6 +142,9 @@ def main():
     verify = module.params['verify']
     fingerprint = module.params['fingerprint']
 
+    if type(verify) is str and verify.lower() in ("true", "false"):
+        verify = verify.lower() == "true"
+
     Passbolt = passbolt(apiurl=passbolt_uri, privatekey=gpgkey, passphrase=passphrase, fingerprint=fingerprint,
                         verify=verify)
 

--- a/plugins/modules/create_user.py
+++ b/plugins/modules/create_user.py
@@ -126,6 +126,9 @@ def main():
     verify = module.params['verify']
     fingerprint = module.params['fingerprint']
 
+    if type(verify) is str and verify.lower() in ("true", "false"):
+        verify = verify.lower() == "true"
+
     Passbolt = passbolt(apiurl=passbolt_uri, privatekey=gpgkey, passphrase=passphrase, fingerprint=fingerprint,
                         verify=verify)
 

--- a/plugins/modules/delete_group.py
+++ b/plugins/modules/delete_group.py
@@ -98,6 +98,9 @@ def main():
     verify = module.params['verify']
     fingerprint = module.params['fingerprint']
 
+    if type(verify) is str and verify.lower() in ("true", "false"):
+        verify = verify.lower() == "true"
+
     Passbolt = passbolt(apiurl=passbolt_uri, privatekey=gpgkey, passphrase=passphrase, fingerprint=fingerprint,
                         verify=verify)
 

--- a/plugins/modules/delete_password.py
+++ b/plugins/modules/delete_password.py
@@ -107,6 +107,9 @@ def main():
     verify = module.params['verify']
     fingerprint = module.params['fingerprint']
 
+    if type(verify) is str and verify.lower() in ("true", "false"):
+        verify = verify.lower() == "true"
+
     Passbolt = passbolt(apiurl=passbolt_uri, privatekey=gpgkey, passphrase=passphrase, fingerprint=fingerprint,
                         verify=verify)
 

--- a/plugins/modules/delete_user.py
+++ b/plugins/modules/delete_user.py
@@ -98,6 +98,9 @@ def main():
     verify = module.params['verify']
     fingerprint = module.params['fingerprint']
 
+    if type(verify) is str and verify.lower() in ("true", "false"):
+        verify = verify.lower() == "true"
+
     Passbolt = passbolt(apiurl=passbolt_uri, privatekey=gpgkey, passphrase=passphrase, fingerprint=fingerprint,
                         verify=verify)
 

--- a/plugins/modules/get_or_create_password.py
+++ b/plugins/modules/get_or_create_password.py
@@ -136,6 +136,9 @@ def main():
     verify = module.params['verify']
     fingerprint = module.params['fingerprint']
 
+    if type(verify) is str and verify.lower() in ("true", "false"):
+        verify = verify.lower() == "true"
+
     Passbolt = passbolt(apiurl=passbolt_uri, privatekey=gpgkey, passphrase=passphrase, fingerprint=fingerprint,
                         verify=verify)
     existing_password = Passbolt.getpassword(name, username)

--- a/plugins/modules/share_password.py
+++ b/plugins/modules/share_password.py
@@ -141,6 +141,9 @@ def main():
     verify = module.params['verify']
     fingerprint = module.params['fingerprint']
 
+    if type(verify) is str and verify.lower() in ("true", "false"):
+        verify = verify.lower() == "true"
+
     Passbolt = passbolt(apiurl=passbolt_uri, privatekey=gpgkey, passphrase=passphrase, fingerprint=fingerprint,
                         verify=verify)
 

--- a/plugins/modules/update_group.py
+++ b/plugins/modules/update_group.py
@@ -121,9 +121,12 @@ def main():
     users = module.params['users']
     verify = module.params['verify']
     fingerprint = module.params['fingerprint']
+
+    if type(verify) is str and verify.lower() in ("true", "false"):
+        verify = verify.lower() == "true"
+
     Passbolt = passbolt(apiurl=passbolt_uri, privatekey=gpgkey, passphrase=passphrase, fingerprint=fingerprint,
                         verify=verify)
-
 
     response = Passbolt.updategroup(name, admins, users)
     if response == "The operation was successful.":

--- a/plugins/modules/update_password.py
+++ b/plugins/modules/update_password.py
@@ -160,6 +160,9 @@ def main():
     verify = module.params['verify']
     fingerprint = module.params['fingerprint']
 
+    if type(verify) is str and verify.lower() in ("true", "false"):
+        verify = verify.lower() == "true"
+
     Passbolt = passbolt(apiurl=passbolt_uri, privatekey=gpgkey, passphrase=passphrase, fingerprint=fingerprint,
                         verify=verify)
 

--- a/plugins/modules/update_user.py
+++ b/plugins/modules/update_user.py
@@ -126,6 +126,9 @@ def main():
     verify = module.params['verify']
     fingerprint = module.params['fingerprint']
 
+    if type(verify) is str and verify.lower() in ("true", "false"):
+        verify = verify.lower() == "true"
+
     Passbolt = passbolt(apiurl=passbolt_uri, privatekey=gpgkey, passphrase=passphrase, fingerprint=fingerprint,
                         verify=verify)
 


### PR DESCRIPTION
The parameter verify is defined as type str. When verify is set in a task it will be a string and interpreted as a ca path. 
https://github.com/daniel-lynch/daniel_lynch.passbolt/blob/main/plugins/modules/delete_password.py#L94

The python request library expects a bool or a string (path).
https://github.com/psf/requests/blob/main/requests/api.py#L39

This fix adds a type cast in case a bool in form of a str is given like "true", "false", "True", "False".

